### PR TITLE
PRF: Optimize GB line search regression (RFC: is it worth it?) 

### DIFF
--- a/sklearn/_loss/loss.py
+++ b/sklearn/_loss/loss.py
@@ -46,7 +46,7 @@ from sklearn._loss.link import (
     MultinomialLogit,
 )
 from sklearn.utils import check_scalar
-from sklearn.utils.stats import _weighted_percentile, weighted_quantile_by_idx
+from sklearn.utils.stats import _weighted_percentile, _weighted_quantile_by_idx
 
 
 # Note: The shape of raw_prediction for multiclass classifications are
@@ -614,7 +614,7 @@ class AbsoluteError(BaseLoss):
         if sample_weight is None:
             sample_weight = np.ones_like(y_true)
 
-        return weighted_quantile_by_idx(y_true, sample_weight, idx, quantile=0.5)
+        return _weighted_quantile_by_idx(y_true, sample_weight, idx, quantile=0.5)
 
 
 class PinballLoss(BaseLoss):
@@ -703,7 +703,7 @@ class PinballLoss(BaseLoss):
         if sample_weight is None:
             sample_weight = np.ones_like(y_true)
 
-        return weighted_quantile_by_idx(
+        return _weighted_quantile_by_idx(
             y_true, sample_weight, idx, quantile=self.closs.quantile
         )
 
@@ -805,7 +805,7 @@ class HuberLoss(BaseLoss):
             sample_weight = np.ones_like(y_true)
 
         # Compute weighted median per group (quantile=0.5)
-        median = weighted_quantile_by_idx(y_true, sample_weight, idx, quantile=0.5)
+        median = _weighted_quantile_by_idx(y_true, sample_weight, idx, quantile=0.5)
 
         # Compute Huber adjustment term per group
         diff = y_true - median[idx]

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -49,7 +49,7 @@ from sklearn.exceptions import NotFittedError
 from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import LabelEncoder
 from sklearn.tree import DecisionTreeRegressor
-from sklearn.tree._tree import DOUBLE, DTYPE, TREE_LEAF
+from sklearn.tree._tree import DOUBLE, DTYPE
 from sklearn.utils import check_array, check_random_state, column_or_1d
 from sklearn.utils._param_validation import HasMethods, Hidden, Interval, StrOptions
 from sklearn.utils.multiclass import check_classification_targets
@@ -226,20 +226,18 @@ def _update_terminal_regions(
     else:
         # regression losses other than the squared error.
         # As of now: absolute error, pinball loss, huber loss.
-
-        # mask all which are not in sample mask.
-        masked_terminal_regions = terminal_regions.copy()
-        masked_terminal_regions[~sample_mask] = -1
-        # update each leaf (= perform line search)
-        for leaf in np.nonzero(tree.children_left == TREE_LEAF)[0]:
-            (indices,) = np.nonzero(masked_terminal_regions == leaf)
-            sw = None if sample_weight is None else sample_weight[indices]
-            update = loss.fit_intercept_only(
-                y_true=y[indices] - raw_prediction[indices, k],
-                sample_weight=sw,
+        if sample_mask.all():
+            idx = terminal_regions
+            residual = y - raw_prediction[:, k]
+        else:
+            sample_weight = (
+                None if sample_weight is None else sample_weight[sample_mask]
             )
+            residual = y[sample_mask] - raw_prediction[sample_mask, k]
+            idx = terminal_regions[sample_mask]
 
-            tree.value[leaf, 0, 0] = update
+        update = loss.fit_intercept_only_by_idx(idx, residual, sample_weight)
+        tree.value[:, 0, 0] = update
 
     # update predictions (both in-bag and out-of-bag)
     raw_prediction[:, k] += learning_rate * tree.value[:, 0, 0].take(

--- a/sklearn/utils/stats.py
+++ b/sklearn/utils/stats.py
@@ -217,7 +217,7 @@ def _weighted_percentile(
     return result[0, ...] if n_dim == 1 else result
 
 
-def weighted_quantile_by_idx(y, w, idx, quantile=0.5):
+def _weighted_quantile_by_idx(y, w, idx, quantile=0.5):
     """Compute weighted quantile for groups defined by idx.
 
     Parameters

--- a/sklearn/utils/tests/test_stats.py
+++ b/sklearn/utils/tests/test_stats.py
@@ -12,7 +12,7 @@ from sklearn.utils._array_api import (
 from sklearn.utils._array_api import device as array_device
 from sklearn.utils.estimator_checks import _array_api_for_tests
 from sklearn.utils.fixes import np_version, parse_version
-from sklearn.utils.stats import _weighted_percentile
+from sklearn.utils.stats import _weighted_percentile, weighted_quantile_by_idx
 
 
 @pytest.mark.parametrize("average", [True, False])
@@ -483,3 +483,170 @@ def test_weighted_percentile_like_numpy_nanquantile(
     )
 
     assert_array_equal(percentile_weighted_percentile, percentile_numpy_nanquantile)
+
+
+def test_weighted_quantile_by_idx_basic():
+    """Test basic functionality of weighted_quantile_by_idx with median."""
+    y = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+    w = np.array([1.0, 1.0, 1.0, 1.0, 1.0, 1.0])
+    idx = np.array([0, 0, 0, 1, 1, 1])
+
+    result = weighted_quantile_by_idx(y, w, idx, quantile=0.5)
+
+    # Using "inverted_cdf" method
+    # Group 0: [1, 2, 3] -> cumsum [1, 2, 3], threshold=1.5,
+    #          first >= 1.5 is at cumsum=2 -> y=2
+    # Group 1: [4, 5, 6] -> cumsum [1, 2, 3], threshold=1.5,
+    #          first >= 1.5 is at cumsum=2 -> y=5
+    assert result[0] == approx(2.0)
+    assert result[1] == approx(5.0)
+
+
+def test_weighted_quantile_by_idx_different_quantiles():
+    """Test weighted_quantile_by_idx with different quantile levels."""
+    y = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    w = np.array([1.0, 1.0, 1.0, 1.0, 1.0])
+    idx = np.array([0, 0, 0, 0, 0])
+
+    # Test different quantiles
+    result_q25 = weighted_quantile_by_idx(y, w, idx, quantile=0.25)
+    result_q50 = weighted_quantile_by_idx(y, w, idx, quantile=0.5)
+    result_q75 = weighted_quantile_by_idx(y, w, idx, quantile=0.75)
+
+    # For uniform weights [1,2,3,4,5]: cumulative weights are [1,2,3,4,5]
+    # q=0.25: 0.25*5=1.25, first >= 1.25 is at cumsum=2 -> y=2
+    # q=0.50: 0.50*5=2.5, first >= 2.5 is at cumsum=3 -> y=3
+    # q=0.75: 0.75*5=3.75, first >= 3.75 is at cumsum=4 -> y=4
+    assert result_q25[0] == approx(2.0)
+    assert result_q50[0] == approx(3.0)
+    assert result_q75[0] == approx(4.0)
+
+
+def test_weighted_quantile_by_idx_weighted():
+    """Test weighted_quantile_by_idx with non-uniform weights."""
+    y = np.array([1.0, 2.0, 3.0])
+    w = np.array([1.0, 2.0, 1.0])  # Total weight = 4
+    idx = np.array([0, 0, 0])
+
+    result = weighted_quantile_by_idx(y, w, idx, quantile=0.5)
+
+    # Cumulative weights: [1, 3, 4]
+    # Median at 0.5*4=2.0, first cumsum >= 2.0 is 3 -> y=2
+    assert result[0] == approx(2.0)
+
+
+def test_weighted_quantile_by_idx_multiple_groups():
+    """Test weighted_quantile_by_idx with multiple groups."""
+    y = np.array([5.0, 1.0, 3.0, 2.0, 4.0, 6.0])
+    w = np.array([1.0, 1.0, 1.0, 1.0, 1.0, 1.0])
+    idx = np.array([1, 0, 0, 1, 2, 2])
+
+    result = weighted_quantile_by_idx(y, w, idx, quantile=0.5)
+
+    # Using "inverted_cdf" method (like _weighted_percentile with average=False)
+    # Group 0: [1, 3] -> cumsum [1, 2], threshold=1.0,
+    #          first >= 1.0 is at cumsum=1 -> y=1
+    # Group 1: [2, 5] -> cumsum [1, 2], threshold=1.0,
+    #          first >= 1.0 is at cumsum=1 -> y=2
+    # Group 2: [4, 6] -> cumsum [1, 2], threshold=1.0,
+    #          first >= 1.0 is at cumsum=1 -> y=4
+    assert result[0] == approx(1.0)
+    assert result[1] == approx(2.0)
+    assert result[2] == approx(4.0)
+
+
+def test_weighted_quantile_by_idx_missing_groups():
+    """Test that missing group indices return NaN."""
+    y = np.array([1.0, 2.0, 3.0])
+    w = np.array([1.0, 1.0, 1.0])
+    idx = np.array([0, 0, 2])  # Group 1 is missing
+
+    result = weighted_quantile_by_idx(y, w, idx, quantile=0.5)
+
+    # Group 0: [1, 2] -> cumsum [1, 2], threshold=1.0,
+    #          first >= 1.0 is at cumsum=1 -> y=1
+    assert result[0] == approx(1.0)
+    assert np.isnan(result[1])  # Group 1: missing
+    assert result[2] == approx(3.0)  # Group 2: only [3]
+
+
+def test_weighted_quantile_by_idx_single_value_per_group():
+    """Test with single value per group."""
+    y = np.array([10.0, 20.0, 30.0])
+    w = np.array([1.0, 2.0, 3.0])
+    idx = np.array([0, 1, 2])
+
+    result = weighted_quantile_by_idx(y, w, idx, quantile=0.5)
+
+    # Each group has only one value, so that value is the quantile
+    assert result[0] == approx(10.0)
+    assert result[1] == approx(20.0)
+    assert result[2] == approx(30.0)
+
+
+def test_weighted_quantile_by_idx_extreme_quantiles():
+    """Test with extreme quantile values (0 and 1)."""
+    y = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    w = np.array([1.0, 1.0, 1.0, 1.0, 1.0])
+    idx = np.array([0, 0, 0, 0, 0])
+
+    # Quantile 0 should give first value when cumsum > 0
+    result_q0 = weighted_quantile_by_idx(y, w, idx, quantile=0.0)
+    # For q=0, threshold is 0, first cumsum >= 0 is cumsum=1 -> y=1
+    assert result_q0[0] == approx(1.0)
+
+    # Quantile 1 should give last value
+    result_q1 = weighted_quantile_by_idx(y, w, idx, quantile=1.0)
+    # For q=1, threshold is 5, first cumsum >= 5 is cumsum=5 -> y=5
+    assert result_q1[0] == approx(5.0)
+
+
+def test_weighted_quantile_by_idx_unsorted_input():
+    """Test that the function handles unsorted input correctly."""
+    # Input is intentionally unsorted
+    y = np.array([3.0, 1.0, 4.0, 2.0, 5.0])
+    w = np.array([1.0, 1.0, 1.0, 1.0, 1.0])
+    idx = np.array([1, 0, 1, 0, 1])
+
+    result = weighted_quantile_by_idx(y, w, idx, quantile=0.5)
+
+    # Group 0: [1, 2] -> cumsum [1, 2], threshold=1.0,
+    #          first >= 1.0 is at cumsum=1 -> y=1
+    # Group 1: [3, 4, 5] -> cumsum [1, 2, 3], threshold=1.5,
+    #          first >= 1.5 is at cumsum=2 -> y=4
+    assert result[0] == approx(1.0)
+    assert result[1] == approx(4.0)
+
+
+def test_weighted_quantile_by_idx_consistency_with_weighted_percentile():
+    """Test consistency with _weighted_percentile for single group."""
+    rng = np.random.RandomState(42)
+    y = rng.rand(20)
+    w = rng.rand(20)
+    idx = np.zeros(20, dtype=int)  # All in group 0
+
+    for quantile in [0.25, 0.5, 0.75]:
+        result_by_idx = weighted_quantile_by_idx(y, w, idx, quantile=quantile)
+        # _weighted_percentile expects percentile_rank in [0, 100]
+        result_percentile = _weighted_percentile(
+            y, w, percentile_rank=quantile * 100, average=False
+        )
+
+        assert result_by_idx[0] == approx(result_percentile)
+
+
+@pytest.mark.parametrize("quantile", [0.1, 0.25, 0.5, 0.75, 0.9])
+def test_weighted_quantile_by_idx_parametrized_quantiles(quantile):
+    """Test various quantile levels."""
+    y = np.arange(1, 11, dtype=float)  # [1, 2, ..., 10]
+    w = np.ones(10)
+    idx = np.zeros(10, dtype=int)
+
+    result = weighted_quantile_by_idx(y, w, idx, quantile=quantile)
+
+    # Verify result is within the data range
+    assert 1.0 <= result[0] <= 10.0
+    # Verify it's monotonic with quantile level
+    if quantile > 0.5:
+        result_lower = weighted_quantile_by_idx(y, w, idx, quantile=0.5)
+        assert result[0] >= result_lower[0]


### PR DESCRIPTION
#### Reference Issues/PRs

Follow-up from https://github.com/scikit-learn/scikit-learn/pull/32911

#### What does this implement/fix? Explain your changes.

- Implemented `loss.fit_intercept_only_by_idx` for AE, Pinball and Huber losses.
- All those methods are based on `_weighted_quantile_by_idx` that I implemented in `sklearn/utils/stats.py`, alongside `_weighted_percentile`: for now it lacks the option `average=True/False`.
- Used `loss.fit_intercept_only_by_idx` instead of the O(n^2) loop pattern in `_update_terminal_regions` for those losses

I looked into using this in HGB too, but I don't think it'll be useful.

#### AI usage disclosure

Almost fully generated by Copilot. At first glance, it looks fairly good honestly.

I used AI assistance for:
- [X] Code generation (e.g., when writing an implementation or fixing a bug)
- [X] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding


#### Seed-up

Good: 140s -> 4s on this "highest-speedup" example:

```Python
import numpy as np
from sklearn.ensemble import GradientBoostingClassifier, GradientBoostingRegressor

n, d = 100_000, 4
X = np.random.geometric(0.05, size=(n, d))
y = np.random.rand(n)
gb = GradientBoostingRegressor(n_estimators=10, max_depth=None, loss='huber')
gb.fit(X, y)
```

For AE, the speed-up is 60s -> 4s.

#### Is the increased code complexity worth the speed-up (for what is mostly an edge-case)?

I don't know.

The new code from this PR is a relatively nice piece code, and could maybe be used in other places. But it's quite a lot of code too...